### PR TITLE
Rename EFS Mounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,14 @@ flowchart LR
         sg1["Security Group"]
         sg1 --> sam1["SAM Server"]
         sg1 --> ip1["IP Server"]
-        sam1 --> efs1["EFS Mount"]
+        sam1 --> efs1["EFS MOUNT TARGET"]
         ip1 --> efs1
       end
       subgraph AZ2["AZ-2"]
         sg2["Security Group"]
         sg2 --> sam2["SAM Server"]
         sg2 --> ip2["IP Server"]
-        sam2 --> efs2["EFS Mount"]
+        sam2 --> efs2["EFS MOUNT TARGET"]
         ip2 --> efs2
       end
       efs_central["EFS Target"]

--- a/smarts_architecture.html
+++ b/smarts_architecture.html
@@ -521,7 +521,7 @@
                                 <div class="ec2 ip-server-1">IP Server</div>
                             </div>
 
-                            <div class="efs efs-mount-1">EFS Mount</div>
+                            <div class="efs efs-mount-1">EFS MOUNT TARGET</div>
                         </div>
                     </div>
                     
@@ -540,7 +540,7 @@
                                 <div class="ec2 ip-server-2">IP Server</div>
                             </div>
 
-                            <div class="efs efs-mount-2">EFS Mount</div>
+                            <div class="efs efs-mount-2">EFS MOUNT TARGET</div>
                         </div>
                     </div>
                     
@@ -567,7 +567,7 @@
                                 <div class="ec2 dr-sam-server">SAM Server</div>
                                 <div class="ec2 dr-ip-server">IP Server</div>
                             </div>
-                            <div class="efs efs-dr-mount-1">EFS Mount</div>
+                            <div class="efs efs-dr-mount-1">EFS MOUNT TARGET</div>
                         </div>
                     </div>
 
@@ -582,7 +582,7 @@
                                 <div class="ec2 dr-sam-server">SAM Server</div>
                                 <div class="ec2 dr-ip-server">IP Server</div>
                             </div>
-                            <div class="efs efs-dr-mount-2">EFS Mount</div>
+                            <div class="efs efs-dr-mount-2">EFS MOUNT TARGET</div>
                         </div>
                     </div>
                 </div>

--- a/smarts_architecture.mmd
+++ b/smarts_architecture.mmd
@@ -16,14 +16,14 @@ flowchart LR
         sg1["Security Group"]
         sg1 --> sam1["SAM Server"]
         sg1 --> ip1["IP Server"]
-        sam1 --> efs1["EFS Mount"]
+        sam1 --> efs1["EFS MOUNT TARGET"]
         ip1 --> efs1
       end
       subgraph AZ2["AZ-2"]
         sg2["Security Group"]
         sg2 --> sam2["SAM Server"]
         sg2 --> ip2["IP Server"]
-        sam2 --> efs2["EFS Mount"]
+        sam2 --> efs2["EFS MOUNT TARGET"]
         ip2 --> efs2
       end
       efs_central["EFS Target"]


### PR DESCRIPTION
## Summary
- rename EFS Mount components to `EFS MOUNT TARGET`

## Testing
- `grep -n "EFS MOUNT TARGET" -n smarts_architecture.html`


------
https://chatgpt.com/codex/tasks/task_e_684128ccdef883238c460e6e40b7fa06