### PR TITLE
Remove duplicate EFS target

### DIFF
--- a/smarts_architecture.html
+++ b/smarts_architecture.html
@@ -248,10 +248,6 @@
             left: 220px;
         }
 
-        .efs-central {
-            top: 320px;
-            left: 130px;
-        }
 
         .efs-dr-mount-1 {
             top: 250px;
@@ -544,8 +540,6 @@
                         </div>
                     </div>
                     
-                    <!-- Central Components -->
-                    <div class="efs efs-central">EFS Target</div>
                 </div>
             </div>
             


### PR DESCRIPTION
## Summary
- clean up SAM diagram by dropping the unused `EFS Target` element

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68412a6e0f508323aa59770f56a86db7